### PR TITLE
fix(minimal): add missing react-native-worklets dependency to template

### DIFF
--- a/minimal/package.json
+++ b/minimal/package.json
@@ -40,6 +40,7 @@
     "@types/react": "~19.0.14",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
+    "react-native-worklets": "^0.5.1",
     "typescript": "~5.8.3"
   },
   "resolutions": {


### PR DESCRIPTION
Hey, I found a bug while following the CLI installation guide for [react native reusables](https://reactnativereusables.com/docs/installation)

Starting a fresh project and running `bun run dev` I encountered this error:
```
› Metro waiting on exp://192.168.4.88:8081
› Scan the QR code above with Expo Go (Android) or the Camera app (iOS)

› Web is waiting on http://localhost:8081

› Using Expo Go
› Press s │ switch to development build

› Press a │ open Android
› Press i │ open iOS simulator
› Press w │ open web

› Press j │ open debugger
› Press r │ reload app
› Press m │ toggle menu
› shift+m │ more tools
› Press o │ open project code in your editor

› Press ? │ show all commands

Logs for your project will appear below. Press Ctrl+C to exit.
λ Bundling failed 281ms node_modules/expo-router/node/render.js (1 module)
Web Bundling failed 290ms node_modules/expo-router/entry.js (1 module)

Metro error: node_modules/expo-router/node/render.js: [BABEL] <removed my local app path>/node_modules/expo-router/node/render.js: Cannot find module 'react-native-worklets/plugin'
```

Adding react-native-worklets as a dev dependency fixed this. I'm not sure why this was needed, it looks like this is required due to babel config which just uses nativewind's babel config which is here: https://github.com/nativewind/react-native-css

I think this dependency has been in their config for a while, so I'm not sure why this is needed now. I'm also not sure how to test that this particular change will work, if you have any direction on setting up a test, I'd be happy to test this change before a merge.