### PR TITLE
Update README.md

### DIFF
--- a/minimal/README.md
+++ b/minimal/README.md
@@ -5,7 +5,7 @@ This is a [React Native](https://reactnative.dev/) project built with [Expo](htt
 It was initialized using the following command:
 
 ```bash
-npx react-native-reusables/cli@latest init -t minimal
+npx @react-native-reusables/cli@latest init -t minimal
 ```
 
 ## Getting Started


### PR DESCRIPTION
Added @ to init command because npx only accepts package names in the form [@scope/]pkg[@version]. 

When you pass "react-native-reusables/cli@latest", the slash makes npx treat it like a relative path inside the current folder (react-native-reusables/cli@latest/package.json), so it throws ENOENT.